### PR TITLE
Add raise_error? support for Redis::CommandError

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -8,6 +8,7 @@ module ActiveSupport
       ERRORS_TO_RESCUE = [
         Errno::ECONNREFUSED,
         Errno::EHOSTUNREACH,
+        Redis::CommandError,
         Redis::CannotConnectError,
         Redis::ConnectionError
       ].freeze


### PR DESCRIPTION
This is the exception raised for the following Redis error:

LOADING Redis is loading the dataset in memory